### PR TITLE
g.extension.github: use GRASS GIS 8; manual fixes

### DIFF
--- a/g.extension.github.html
+++ b/g.extension.github.html
@@ -11,7 +11,7 @@ to install it.
 
 <h2>EXAMPLES</h2>
 
-<h3>Download and install of an extension</h3>
+<h3>Download and install of an specific version of a GRASS extension</h3>
 
 Download and install a specific version of <em>i.sentinel</em> (identified
 via GitHub commit hash) into current GRASS GIS installation:

--- a/g.extension.github.html
+++ b/g.extension.github.html
@@ -11,7 +11,7 @@ to install it.
 
 <h2>EXAMPLES</h2>
 
-<h3>Download and install of an specific version of a GRASS extension</h3>
+<h3>Download and install of a specific version of a GRASS extension</h3>
 
 Download and install a specific version of <em>i.sentinel</em> (identified
 via GitHub commit hash) into current GRASS GIS installation:

--- a/g.extension.github.html
+++ b/g.extension.github.html
@@ -2,32 +2,33 @@
 
 <em>g.extension.github</em> downloads and installs, removes or updates
 extensions (addons) from the official
-<a href="https://grass.osgeo.org/grass7/manuals/addons/">GRASS GIS Addons
-  repository</a>. It uses <em><a href="g.extension.html">g.extension</a></em>.
+<a href="https://grass.osgeo.org/grass8/manuals/addons/">GRASS GIS Addons
+  repository</a>. It uses <em>g.extension</em>.
 
 If a commit hash is set as <b>reference</b> then the addon downloads the
-extension from GitHub according to this hash and uses
-<em><a href="g.extension.html">g.extension</a></em> to install it.
+extension from GitHub according to this hash and uses <em>g.extension</em>
+to install it.
 
 <h2>EXAMPLES</h2>
 
 <h3>Download and install of an extension</h3>
 
-Download and install <em>r.stream.distance</em> into current GRASS installation
+Download and install a specific version of <em>i.sentinel</em> (identified
+via GitHub commit hash) into current GRASS GIS installation:
 
 <div class="code"><pre>
-g.extension.github extension=i.sentinel -f reference=0e61c94d2b4aab5f22a6b001cf0b2dc2c46662ba
+g.extension.github extension=i.sentinel -f reference=aff69a9a0dac8c68ccb877858675d84588b35bd2
 </pre></div>
 
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="g.extension.html">g.extension</a>
+<a href="https://grass.osgeo.org/grass-stable/manuals/g.extension.html">g.extension</a>
 </em>
 
-<h2>AUTHORS</h2>
+<h2>AUTHOR</h2>
 
-Anika Weinmann, mundialis<br>
+Anika Weinmann, <a href="https://www.mundialis.de/">mundialis</a>, Germany
 
 <!--
 <p>

--- a/g.extension.github.py
+++ b/g.extension.github.py
@@ -23,7 +23,6 @@
 #############################################################################
 
 # %module
-# % label: Tool to download and install extensions from official GRASS GIS Addons GitHub repo (https://github.com/OSGeo/grass-addons) using g.extension
 # % description: Downloads and installs extensions from GRASS Addons repository using g.extension
 # % keyword: general
 # % keyword: installation
@@ -88,7 +87,7 @@ curr_path = None
 
 
 def cleanup():
-    grass.message(_("Cleaning up.."))
+    grass.message(_("Cleaning up..."))
     for folder in rm_folders:
         if os.path.isdir(folder):
             shutil.rmtree(folder)
@@ -145,10 +144,10 @@ def get_first_dir(commit_url, reference):
     req = urllib.request.urlopen(commit_url + reference)
     content = json.loads(req.read())
     filenames = [file["filename"] for file in content["files"]]
-    # if any path of files in the commit starts with "grass7",
+    # if any path of files in the commit starts with "grass8",
     # then this is assumed as the first directory
-    if any(item.startswith("grass7") for item in filenames):
-        first_dir = "grass7"
+    if any(item.startswith("grass8") for item in filenames):
+        first_dir = "grass8"
     return first_dir
 
 
@@ -212,7 +211,7 @@ def main():
         if process.stderr != b'':
             grass.fatal(_("Configuring the single extension does not work: "
                 "<git config core.sparseCheckout true> failed"))
-        # echo "grass7/imagery/i.sentinel"  > .git/info/sparse-checkout
+        # echo "grass8/imagery/i.sentinel"  > .git/info/sparse-checkout
         gversion = "grass{}".format(grass.version()['version'].split('.')[0])
         ext_type = get_module_class(extension)
         extension_folder = "{}/{}/{}".format(gversion, ext_type, extension)

--- a/g.extension.github.py
+++ b/g.extension.github.py
@@ -142,6 +142,7 @@ def get_first_dir(commit_url, reference):
     # /src
     first_dir = "src"
     req = urllib.request.urlopen(commit_url + reference)
+    grass.verbose(commit_url + reference)
     content = json.loads(req.read())
     filenames = [file["filename"] for file in content["files"]]
     # if any path of files in the commit starts with "grass8",


### PR DESCRIPTION
- update to use GRASS GIS 8 instead of 7
- manual:
  - example fix
  - fix URLs (GRASS-core URLs are absolute, addon-URLs relative)