### PR TITLE
change so that github auth can be used

### DIFF
--- a/g.extension.github.py
+++ b/g.extension.github.py
@@ -86,7 +86,6 @@ import grass.script as grass
 
 rm_folders = []
 curr_path = None
-opener = None
 
 
 def cleanup():
@@ -178,7 +177,7 @@ def get_first_dir(commit_url, reference):
 
 def main():
 
-    global rm_folders, opener
+    global rm_folders
 
     extension = options["extension"]
     operation = options["operation"]

--- a/g.extension.github.py
+++ b/g.extension.github.py
@@ -78,10 +78,22 @@ import os
 import shutil
 import sys
 import base64
-import requests
 import urllib.request
 
 import grass.script as grass
+
+try:
+    import requests
+except ImportError:
+    grass.fatal(
+        _(
+            "Cannot import requests (https://docs.python-requests.org/en/latest/)"
+            " library."
+            " Please install it (pip install requests)"
+            " or ensure that it is on path"
+            " (u se PYTHONPATH variable)."
+        )
+    )
 
 
 rm_folders = []

--- a/g.extension.github.py
+++ b/g.extension.github.py
@@ -80,15 +80,6 @@ import sys
 import base64
 import requests
 import urllib.request
-# try:
-#     from urllib2 import urlopen, URLError, HTTPError, urlretrieve
-#     from urllib2 import build_opener, install_opener
-#     from urllib2 import HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler
-# except ImportError:
-#     from urllib.request import urlopen, urlretrieve
-#     from urllib.request import build_opener, install_opener
-#     from urllib.request import HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler
-#     from urllib.error import URLError, HTTPError
 
 import grass.script as grass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
The `rate_limit` of github is not so high if no authentication is set. To avaid the very low `rate_limit` now `GITHUB_USERNAME` and `GITHUB_TOKEN` can be set as environment variables and the addon will use them to download the new addon.
For this change `requests` is used to download the files.